### PR TITLE
Tighter map object api

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ userMapper = {
 superOM.addMapper(userMapper, "users");
 ```
 
-###`superOM.mapObject(mapName, mapperName, object[, options])`
+###`superOM.mapObject(object, options)`
 
 You can then run any object across the mapper and map of your choosing.
 
@@ -72,7 +72,7 @@ var object = {
   email: "mario@toadstool.com",
   extraneousProperty: "whatever data"
 }
-var databaseObject = superOM.mapObject("database", "users", object);
+var databaseObject = superOM.mapObject(object, {mapper: "users", map: "database"});
 
 console.log(databaseObject);
 //{
@@ -106,7 +106,7 @@ var array = [
     extraneousProperty: "whatever data"
   }
 ]
-var databaseArray = superOM.mapObject("database", "users", array);
+var databaseArray = superOM.mapObject(array, {mapper: "users", map: "database"});
 
 console.log(databaseArray);
 //[
@@ -124,12 +124,11 @@ console.log(databaseArray);
 
 ###options
 
-You can optionally pass a 4th `options` parameter, which defaults as follows:
+You can specify `clean` on the options object to remove falsey values from the
+mapped object.
 
 ```
-options = {
-  clean: false // if `true`, `.mapObject` will remove falsy values from the mapped object
-}
+var mappedObject = superOM.mapObject(object, {mapper: "users", map: "database", clean: true});
 ```
 
 ##SuperOMType

--- a/lib/super-object-mapper.js
+++ b/lib/super-object-mapper.js
@@ -7,40 +7,41 @@ var defaults = {
   }
 };
 
-function SuperOM () {
-};
+function SuperOM () {};
 
 SuperOM.Types = require('./super-object-mapper-types');
 
 SuperOM._mappers = {};
 
-SuperOM.prototype.mapObject = function(map, mapper, object, options) {
+SuperOM.prototype.mapObject = function(object, options) {
   if (!object) return null;
+  //TODO: validation could be more direct, like so:
+  //if (!object.mapper) throw new Error("SuperOM expected object.mapper");
+  //if (!object.map) throw new Error("SuperOM expected object.map");
 
   //Handle Arrays
   if (object instanceof Array) {
     var array = object;
     if (array.length == 0) return [];
-    var mappedArray = [];
     var self = this;
-    array.forEach(function(obj) {
-      mappedArray.push(self.mapObject(map, mapper, obj, options));
+    return array.map(function(obj) {
+      return self.mapObject(obj, options);
     });
-    return mappedArray;
   }
 
+  //TODO: append values
   if (!options) options = defaults.options;
 
   if (!SuperOM._mappers) {
     throw new Error('Init fail: No mappers object');
-  } else if (!SuperOM._mappers[mapper]) {
+  } else if (!SuperOM._mappers[options.mapper]) {
     throw new Error('Mapper not found');
-  } else if (!SuperOM._mappers[mapper][map]) {
+  } else if (!SuperOM._mappers[options.mapper][options.map]) {
     throw new Error('Map not found');
   }
 
   //define mapObject
-  var mapObject = SuperOM._mappers[mapper][map];
+  var mapObject = SuperOM._mappers[options.mapper][options.map];
 
   //collect explict nulls for persisting
   var persistedFalsyValues = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-object-mapper",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Sup-ed up object-level schema control - whitelist fields and convert between types and keys.",
   "main": "index.js",
   "scripts": {

--- a/test/handles-arrays.spec.js
+++ b/test/handles-arrays.spec.js
@@ -11,19 +11,19 @@ describe('Super Object Mapper handles arrays', function() {
 
   it('should return an empty array if one is passed', function() {
     superOM.addMapper({
-      "domain":{
+      "domain": {
         name: 'name'
       }
     }, "users");
     var array = [];
-    var mappedArray = superOM.mapObject("domain", "users", array);
+    var mappedArray = superOM.mapObject(array, {map: "domain", mapper: "users"});
 
     expect(mappedArray).to.eql([]);
   });
 
   it('should return an array of mapped objects in order', function() {
     superOM.addMapper({
-      "domain":{
+      "domain": {
         name: 'name',
         lastEggLaid: 'last_egg_laid',
         "email": "email"
@@ -41,7 +41,7 @@ describe('Super Object Mapper handles arrays', function() {
         lastEggLaid: "June, 1986"
       }
     ];
-    var mappedArray = superOM.mapObject("domain", "users", array);
+    var mappedArray = superOM.mapObject(array, {map: "domain", mapper: "users"});
 
     expect(mappedArray[0].name).to.eql("Luigi");
     expect(mappedArray[1].name).to.eql("Peach");

--- a/test/map-object.spec.js
+++ b/test/map-object.spec.js
@@ -27,7 +27,7 @@ describe('Super Object Mapper .mapObject()', function() {
       email: "mario@toadstool.com",
       secrets: "Sleeps with a blanky named Stewart"
     };
-    var mappedObject = superOM.mapObject(map, mapper, object);
+    var mappedObject = superOM.mapObject(object, {mapper: mapper, map: map});
 
     it('should return a mapped object', function() {
       expect(mappedObject).to.exist();
@@ -52,7 +52,7 @@ describe('Super Object Mapper .mapObject()', function() {
       var object = {
         "name": "William Franklyn Bowser"
       };
-      var mapObjectFunc = superOM.mapObject.bind(superOM, "database", "gremlins", object);
+      var mapObjectFunc = superOM.mapObject.bind(superOM, object, {map: "database", mapper: "gremlins"});
 
       expect(mapObjectFunc).to.throw(/Mapper not found/);
     });
@@ -66,7 +66,7 @@ describe('Super Object Mapper .mapObject()', function() {
       var object = {
         "name": "William Franklyn Bowser"
       };
-      var mapObjectFunc = superOM.mapObject.bind(superOM, "database", "koopas", object);
+      var mapObjectFunc = superOM.mapObject.bind(superOM, object, {map: "database", mapper: "koopas"});
 
       expect(mapObjectFunc).to.throw(/Map not found/);
     });
@@ -76,14 +76,14 @@ describe('Super Object Mapper .mapObject()', function() {
     var superOM = new SuperOM();
     it('should return null if the object is null', function() {
       superOM.addMapper({"domain":{}}, "users");
-      var mappedObject = superOM.mapObject("domain", "users", null);
+      var mappedObject = superOM.mapObject(null, {map: "domain", mapper: "users"});
 
       expect(mappedObject).to.equal(null);
     });
 
     it('should persist explicit null or undefined fields by default', function() {
       superOM.addMapper({
-        "domain":{
+        "domain": {
           name: 'name',
           fieldSetToNull: 'fieldSetToNull',
           fieldSetToUndefined: 'fieldSetToUndefined',
@@ -96,7 +96,7 @@ describe('Super Object Mapper .mapObject()', function() {
         fieldSetToUndefined: null,
         nullField: null
       };
-      var mappedObject = superOM.mapObject("domain", "users", object);
+      var mappedObject = superOM.mapObject(object, {map: "domain", mapper: "users"});
 
       expect(mappedObject).to.have.property('fieldSetToNull').and.eql(null);
       expect(mappedObject).to.have.property('fieldSetToUndefined').and.eql(null);
@@ -105,7 +105,7 @@ describe('Super Object Mapper .mapObject()', function() {
 
     it('should remove null or undefined fields if {clean: true} passed as an option', function() {
       superOM.addMapper({
-        "domain":{
+        "domain": {
           name: 'name',
           fieldSetToNull: 'fieldSetToNull',
           fieldSetToUndefined: 'fieldSetToUndefined'
@@ -116,10 +116,10 @@ describe('Super Object Mapper .mapObject()', function() {
         fieldSetToNull: null,
         fieldSetToUndefined: null
       };
-      var mappedObject = superOM.mapObject("domain", "users", object, {clean: true});
+      var mappedObject = superOM.mapObject(object, {map: "domain", mapper: "users", clean: true});
 
-      expect(mappedObject).not.to.have.property('fieldSetToNull')
-      expect(mappedObject).not.to.have.property('fieldSetToUndefined')
+      expect(mappedObject).not.to.have.property('fieldSetToNull');
+      expect(mappedObject).not.to.have.property('fieldSetToUndefined');
     });
 
     it('(unless {clean:true}) should not set properties that are not on the original object', function() {
@@ -132,7 +132,7 @@ describe('Super Object Mapper .mapObject()', function() {
       var object = {
         name: 'Johnny Bravo'
       };
-      var mappedObject = superOM.mapObject('domain', 'users', object);
+      var mappedObject = superOM.mapObject(object, {map: 'domain', mapper: 'users'});
 
       expect(mappedObject).not.to.have.property('notOnObject');
     });

--- a/test/super-om-types.spec.js
+++ b/test/super-om-types.spec.js
@@ -21,7 +21,7 @@ describe('Super Object Mapper type enforcement', function() {
       var object = {
         name: "Johnny"
       };
-      var mappedObject = superOM.mapObject("domain", "users", object);
+      var mappedObject = superOM.mapObject(object, {map: "domain", mapper: "users"});
 
       expect(mappedObject.doodle).to.be.a("string").and.equal(object.name)
         .and.exist();
@@ -36,7 +36,7 @@ describe('Super Object Mapper type enforcement', function() {
       var object = {
         name: null
       };
-      var mappedObject = superOM.mapObject("domain", "users", object);
+      var mappedObject = superOM.mapObject(object, {map: "domain", mapper: "users"});
 
       expect(mappedObject).to.have.property('name').and.eql(null);
     });
@@ -48,7 +48,7 @@ describe('Super Object Mapper type enforcement', function() {
         }
       }, "users");
       var object = { };
-      var mappedObject = superOM.mapObject("domain", "users", object);
+      var mappedObject = superOM.mapObject(object, {map: "domain", mapper: "users"});
 
       expect(mappedObject).not.to.have.property("name");
     });
@@ -70,7 +70,7 @@ describe('Super Object Mapper type enforcement', function() {
         var object = {
           attr: tData.value
         };
-        var mappedObject = superOM.mapObject("domain", "users", object);
+        var mappedObject = superOM.mapObject(object, {map: "domain", mapper: "users"});
 
         expect(mappedObject.attr).to.be.a("string").and.equal(tData.expected)
           .and.exist();
@@ -92,7 +92,7 @@ describe('Super Object Mapper type enforcement', function() {
       var object = {
         name: ObjectID("123456abcdef654321fedcba")
       };
-      var mappedObject = superOM.mapObject("domain", "users", object);
+      var mappedObject = superOM.mapObject(object, {map: "domain", mapper: "users"});
 
       expect(mappedObject.doodle).to.be.an.instanceof(ObjectID).and.eql(object.name)
         .and.exist();
@@ -107,7 +107,7 @@ describe('Super Object Mapper type enforcement', function() {
       var object = {
         name: null
       };
-      var mappedObject = superOM.mapObject("domain", "users", object);
+      var mappedObject = superOM.mapObject(object, {map: "domain", mapper: "users"});
 
       expect(mappedObject).to.have.property('name').and.eql(null);
     });
@@ -119,7 +119,7 @@ describe('Super Object Mapper type enforcement', function() {
         }
       }, "users");
       var object = { };
-      var mappedObject = superOM.mapObject("domain", "users", object);
+      var mappedObject = superOM.mapObject(object, {map: "domain", mapper: "users"});
 
       expect(mappedObject).not.to.have.property("name");
     });
@@ -139,7 +139,7 @@ describe('Super Object Mapper type enforcement', function() {
         var object = {
           attr: tData.value
         };
-        var mappedObject = superOM.mapObject("domain", "users", object);
+        var mappedObject = superOM.mapObject(object, {map: "domain", mapper: "users"});
 
         expect(mappedObject.attr).to.be.an.instanceof(ObjectID).and.eql(tData.expected)
           .and.exist();


### PR DESCRIPTION
Moves api from `mapObject(map, mapper, object)` to `mapObject(object, {map: map, mapper: mapper})`