### PR TITLE
Mapper as closure per object

### DIFF
--- a/lib/super-object-mapper.js
+++ b/lib/super-object-mapper.js
@@ -29,6 +29,11 @@ SuperOM.prototype.mapObject = function(object, options) {
     });
   }
 
+  if (options.mapper instanceof Function) {
+    options.mapper = options.mapper();
+    console.log(options.mapper);
+  }
+
   //TODO: append values
   if (!options) options = defaults.options;
 

--- a/lib/super-object-mapper.js
+++ b/lib/super-object-mapper.js
@@ -32,7 +32,6 @@ SuperOM.prototype.mapObject = function(object, options) {
   var mapper = "";
   if (options.mapper instanceof Function) {
     mapper = options.mapper(object);
-    console.log(mapper);
   } else {
     mapper = options.mapper;
   }

--- a/lib/super-object-mapper.js
+++ b/lib/super-object-mapper.js
@@ -29,9 +29,12 @@ SuperOM.prototype.mapObject = function(object, options) {
     });
   }
 
+  var mapper = "";
   if (options.mapper instanceof Function) {
-    options.mapper = options.mapper();
-    console.log(options.mapper);
+    mapper = options.mapper(object);
+    console.log(mapper);
+  } else {
+    mapper = options.mapper;
   }
 
   //TODO: append values
@@ -39,14 +42,14 @@ SuperOM.prototype.mapObject = function(object, options) {
 
   if (!SuperOM._mappers) {
     throw new Error('Init fail: No mappers object');
-  } else if (!SuperOM._mappers[options.mapper]) {
+  } else if (!SuperOM._mappers[mapper]) {
     throw new Error('Mapper not found');
-  } else if (!SuperOM._mappers[options.mapper][options.map]) {
+  } else if (!SuperOM._mappers[mapper][options.map]) {
     throw new Error('Map not found');
   }
 
   //define mapObject
-  var mapObject = SuperOM._mappers[options.mapper][options.map];
+  var mapObject = SuperOM._mappers[mapper][options.map];
 
   //collect explict nulls for persisting
   var persistedFalsyValues = {};

--- a/test/map-object.spec.js
+++ b/test/map-object.spec.js
@@ -8,41 +8,119 @@ describe('Super Object Mapper .mapObject()', function() {
   });
 
   describe('maps a defined object to a specified map', function() {
-    var superOM = new SuperOM();
 
-    var userMapper = {
-      "database": {
-        "name": "name",
-        "email": "emailAddress"
+    describe('hardcoded mapper name', function() {
+      var superOM = new SuperOM();
+
+      var userMapper = {
+        "database": {
+          "name": "name",
+          "email": "emailAddress"
+        }
+      };
+
+      var mapper = 'users';
+
+      superOM.addMapper(userMapper, mapper);
+
+      var map = 'database';
+      var object = {
+        name: "Mario",
+        email: "mario@toadstool.com",
+        secrets: "Sleeps with a blanky named Stewart"
+      };
+      var mappedObject = superOM.mapObject(object, {mapper: mapper, map: map});
+
+      it('should return a mapped object', function() {
+        expect(mappedObject).to.exist();
+      });
+
+      it('should transfer values', function() {
+        expect(mappedObject.name).to.equal(object.name).and.exist();
+      });
+
+      it('should change keys as specified', function() {
+        expect(mappedObject.emailAddress).to.equal(object.email).and.exist();
+      });
+
+      it('should not include fields that are not in the mapper', function() {
+        expect(mappedObject.secrets).not.to.exist();
+      });
+    });
+
+    describe('mapper name as closure', function() {
+      var superOM = new SuperOM();
+
+      var userMapper = {
+        "userToDatabase": {
+          "name": "name",
+          "email": "emailAddress"
+        }
+      };
+
+      var adminMapper = {
+        "userToDatabase": {
+          "name": "name",
+          "email": "emailAddress",
+          "admin": "admin"
+        }
+      };
+
+      var userSession = {
+      };
+      var adminSession = {
+        admin: true
+      };
+      function isAdmin(user) {
+        return user.admin ? true : false;
       }
-    };
+      var adminCheck = function(user) {
+        return function() {
+          if (isAdmin(user)) {
+            return 'admin';
+          } else {
+            return 'user';
+          }
+        };
+      };
 
-    var mapper = 'users';
+      superOM.addMapper(userMapper, "user");
+      superOM.addMapper(adminMapper, "admin");
 
-    superOM.addMapper(userMapper, mapper);
+      var map = 'userToDatabase';
+      var object = {
+        name: "Mario",
+        email: "mario@toadstool.com",
+        secrets: "Sleeps with a blanky named Stewart",
+        admin: true
+      };
+      var userMappedObject = superOM.mapObject(object, {mapper: adminCheck(userSession), map: map});
+      var adminMappedObject = superOM.mapObject(object, {mapper: adminCheck(adminSession), map: map});
 
-    var map = 'database';
-    var object = {
-      name: "Mario",
-      email: "mario@toadstool.com",
-      secrets: "Sleeps with a blanky named Stewart"
-    };
-    var mappedObject = superOM.mapObject(object, {mapper: mapper, map: map});
+      it('should return a mapped object', function() {
+        expect(userMappedObject).to.exist();
+        expect(adminMappedObject).to.exist();
+      });
 
-    it('should return a mapped object', function() {
-      expect(mappedObject).to.exist();
-    });
+      it('should transfer values', function() {
+        expect(userMappedObject.name).to.equal(object.name).and.exist();
+        expect(adminMappedObject.name).to.equal(object.name).and.exist();
+      });
 
-    it('should transfer values', function() {
-      expect(mappedObject.name).to.equal(object.name).and.exist();
-    });
+      it('should change keys as specified', function() {
+        expect(userMappedObject.emailAddress).to.equal(object.email).and.exist();
+        expect(adminMappedObject.emailAddress).to.equal(object.email).and.exist();
+      });
 
-    it('should change keys as specified', function() {
-      expect(mappedObject.emailAddress).to.equal(object.email).and.exist();
-    });
+      it('should not include fields that are not in the mapper', function() {
+        expect(userMappedObject.secrets).not.to.exist();
+        expect(adminMappedObject.secrets).not.to.exist();
+      });
 
-    it('should not include fields that are not in the mapper', function() {
-      expect(mappedObject.secrets).not.to.exist();
+      it('should select the proper mapper based on user', function() {
+        expect(userMappedObject.admin).not.to.exist();
+        expect(adminMappedObject.admin).to.equal(true);
+      });
     });
   });
 


### PR DESCRIPTION
When choosing a mapper for your object(s), you can hand in a string OR function that will be called with the individual object. This is useful when you want to filter fields based on who owns the object, i.e. a user can pull a list of other users and receive all of them, but a visitorMapper, friendMapper, and ownerMapper could all be applied based on the current user's relationship with the individual user objects being mapped.

Docs to come.
